### PR TITLE
feat: add accessible tooltip component

### DIFF
--- a/src/components/ui/tooltip.js
+++ b/src/components/ui/tooltip.js
@@ -1,0 +1,42 @@
+import React from "react";
+
+let tooltipId = 0;
+const nextId = () => `tooltip-${++tooltipId}`;
+
+export function TooltipProvider({ children }) {
+  return children;
+}
+
+export function Tooltip({ children }) {
+  const id = nextId();
+  const [trigger, content] = React.Children.toArray(children);
+  const triggerWithId = React.cloneElement(trigger, { tooltipId: id });
+  const contentWithId = React.cloneElement(content, { id });
+  return React.createElement(
+    "span",
+    { className: "relative inline-block group" },
+    triggerWithId,
+    contentWithId
+  );
+}
+
+export function TooltipTrigger({ asChild = false, tooltipId, children, ...props }) {
+  const triggerProps = { "aria-describedby": tooltipId, ...props };
+  if (asChild && React.isValidElement(children)) {
+    return React.cloneElement(children, triggerProps);
+  }
+  return React.createElement("span", triggerProps, children);
+}
+
+export function TooltipContent({ id, className = "", children, ...props }) {
+  return React.createElement(
+    "span",
+    {
+      id,
+      role: "tooltip",
+      className: `absolute z-50 mt-2 hidden group-hover:block group-focus-within:block ${className}`,
+      ...props
+    },
+    children
+  );
+}

--- a/src/components/ui/tooltip.jsx
+++ b/src/components/ui/tooltip.jsx
@@ -1,8 +1,0 @@
-// Minimal no-op tooltip layer
-export function TooltipProvider({ children }) { return children; }
-export function Tooltip({ children }) { return children; }
-export function TooltipTrigger({ asChild=false, children, ...props }) {
-  if (asChild) return children;
-  return <span {...props}>{children}</span>;
-}
-export function TooltipContent({ children }) { return null; }

--- a/src/components/ui/tooltip.test.js
+++ b/src/components/ui/tooltip.test.js
@@ -1,0 +1,29 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import React from 'react';
+import { Tooltip, TooltipTrigger, TooltipContent } from './tooltip.js';
+
+test('Tooltip wires trigger and content with aria-describedby and hover/focus classes', () => {
+  const tooltipElement = Tooltip({
+    children: [
+      React.createElement(
+        TooltipTrigger,
+        { asChild: true },
+        React.createElement('button', null, 'Trigger')
+      ),
+      React.createElement(TooltipContent, { className: 'extra' }, 'Tip text')
+    ]
+  });
+
+  const [triggerEl, contentEl] = tooltipElement.props.children;
+  const renderedTrigger = triggerEl.type({ ...triggerEl.props });
+  const renderedContent = contentEl.type({ ...contentEl.props });
+
+  const triggerProps = renderedTrigger.props;
+  const contentProps = renderedContent.props;
+
+  assert.equal(triggerProps['aria-describedby'], contentProps.id);
+  assert.ok(contentProps.className.includes('group-hover:block'));
+  assert.ok(contentProps.className.includes('group-focus-within:block'));
+  assert.equal(contentProps.role, 'tooltip');
+});


### PR DESCRIPTION
## Summary
- implement lightweight tooltip using `aria-describedby` and CSS hover/focus behaviour
- cover tooltip linkage and interactive classes with node-based tests

## Testing
- `node --test src/components/ui/tooltip.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689b9ac3cd408327b052f220fa4350ae